### PR TITLE
Support for node 6

### DIFF
--- a/lib/proxyIntegration.js
+++ b/lib/proxyIntegration.js
@@ -29,12 +29,17 @@ function process(proxyIntegrationConfig, event) {
     if (proxyIntegrationConfig.cors) {
         addCorsHeaders(headers);
         if (event.httpMethod === 'OPTIONS') {
-            return Promise.resolve({statusCode: 200, headers: headers, body: ''});
+            return Promise.resolve({
+                statusCode: 200,
+                headers: headers,
+                body: ''
+            });
         }
     }
     headers = Object.assign(
-        headers,
-        {'Content-Type': 'application/json'},
+        headers, {
+            'Content-Type': 'application/json'
+        },
         proxyIntegrationConfig.defaultHeaders
     );
 
@@ -45,7 +50,9 @@ function process(proxyIntegrationConfig, event) {
     event.path = normalizeRequestPath(event);
 
     try {
-        const actionConfig = findMatchingActionConfig(event.httpMethod, event.path, proxyIntegrationConfig) || {action: NO_MATCHING_ACTION};
+        const actionConfig = findMatchingActionConfig(event.httpMethod, event.path, proxyIntegrationConfig) || {
+            action: NO_MATCHING_ACTION
+        };
         event.paths = actionConfig.paths;
         if (event.body) {
             try {
@@ -61,19 +68,14 @@ function process(proxyIntegrationConfig, event) {
         return Promise.resolve(actionConfig.action(event)).then(res => {
 
             if (res.body) {
+                const mergedHeaders = Object.assign({}, headers, res.headers);
 
-                const newResponseObject = {
-                    headers: {
-                        ...headers,
-                        ...res.headers
+                return Object.assign({
+                        statusCode: 200
                     },
-                    ...res,
-                };
-
-                return {
-                    statusCode: 200,
-                    ...newResponseObject
-                };
+                    res, {
+                        headers: mergedHeaders
+                    });
             }
 
             return {
@@ -104,22 +106,30 @@ function normalizeRequestPath(event) {
 }
 
 function convertError(error, errorMapping, headers) {
-        if (typeof error.reason === 'string' && errorMapping && errorMapping[error.reason]) {
-            return {statusCode: errorMapping[error.reason], body: JSON.stringify(error.message), headers: headers};
-        }else if(typeof error.status === 'number'){
-            return {statusCode: error.status, body: JSON.stringify(error.message), headers: addCorsHeaders({})};
-        }
-        try{
-            return {
-                statusCode: 500,
-                body: `Generic error: ${JSON.stringify(error)}`,
-                headers: addCorsHeaders({})
-            };
-        }catch(stringifyError){}
+    if (typeof error.reason === 'string' && errorMapping && errorMapping[error.reason]) {
+        return {
+            statusCode: errorMapping[error.reason],
+            body: JSON.stringify(error.message),
+            headers: headers
+        };
+    } else if (typeof error.status === 'number') {
+        return {
+            statusCode: error.status,
+            body: JSON.stringify(error.message),
+            headers: addCorsHeaders({})
+        };
+    }
+    try {
         return {
             statusCode: 500,
-            body: `Generic error: ${error.stack ? error.stack : error}`
+            body: `Generic error: ${JSON.stringify(error)}`,
+            headers: addCorsHeaders({})
         };
+    } catch (stringifyError) {}
+    return {
+        statusCode: 500,
+        body: `Generic error: ${error.stack ? error.stack : error}`
+    };
 }
 
 function findMatchingActionConfig(httpMethod, httpPath, routeConfig) {
@@ -138,7 +148,10 @@ function findMatchingActionConfig(httpMethod, httpPath, routeConfig) {
             if (routeConfig.debug) {
                 console.log(`Found matching route ${route.path} with paths`, paths);
             }
-            return {action: route.action, paths: paths};
+            return {
+                action: route.action,
+                paths: paths
+            };
         }
     }
     if (routeConfig.debug) {

--- a/test/proxyIntegration.spec.js
+++ b/test/proxyIntegration.spec.js
@@ -363,6 +363,9 @@ describe('proxyIntegration.routeHandler.returnvalues', () => {
 
         const customBody = {
             statusCode: 201,
+            headers: {
+                'x-test-header': 'x-value'
+            },
             body: JSON.stringify({foo: 'bar'})
         };
 
@@ -375,6 +378,7 @@ describe('proxyIntegration.routeHandler.returnvalues', () => {
             expect(res).toEqual({
                 statusCode: 201,
                 headers: {
+                    'x-test-header': 'x-value',
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({foo: 'bar'})

--- a/test/proxyIntegration.spec.js
+++ b/test/proxyIntegration.spec.js
@@ -374,7 +374,9 @@ describe('proxyIntegration.routeHandler.returnvalues', () => {
         proxyIntegration(routeConfig, {path: '/', httpMethod: 'GET'}).then(res => {
             expect(res).toEqual({
                 statusCode: 201,
-                headers: jasmine.anything(),
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 body: JSON.stringify({foo: 'bar'})
             });
             done();


### PR DESCRIPTION
Spread operator doesn't work on node 6, didn't want to break backwards compatibility for downstream clients who may be using this library incase of merge back into origin